### PR TITLE
Fix/sparql executor

### DIFF
--- a/public/.well-known/mcp.json
+++ b/public/.well-known/mcp.json
@@ -46,17 +46,23 @@
     },
     {
       "name": "queryGraph",
-      "description": "Run a SPARQL query or update against asserted data (urn:vg:data). Workspace namespace prefixes are injected automatically. Supported forms: SELECT (return bindings), CONSTRUCT (return triples, read-only), INSERT DATA, DELETE DATA, DELETE WHERE, DELETE...INSERT...WHERE. For OWL-RL inference use runReasoning instead.",
+      "description": "Run a SPARQL query or update against the RDF store. Workspace namespace prefixes are injected automatically so you can use short prefix:local notation. Asserted data is in urn:vg:data; inferred triples (after runReasoning) are in urn:vg:inferred — plain BGP patterns match both. Supported forms: SELECT (returns {rows, total, truncated}), CONSTRUCT (returns {triples, total, truncated}), INSERT DATA, DELETE DATA, DELETE WHERE, DELETE…INSERT…WHERE (returns {updated:true}). Results are capped at limit (default 200, max 1000); truncated:true means more rows exist — use SPARQL OFFSET for pagination. For OWL-RL inference use runReasoning instead.",
       "inputSchema": {
         "type": "object",
-        "properties": {
-          "sparql": {
-            "type": "string"
-          }
-        },
         "required": [
           "sparql"
-        ]
+        ],
+        "properties": {
+          "sparql": {
+            "type": "string",
+            "description": "SPARQL query or update. Prefix notation supported (e.g. ex:Alice, owl:Class)."
+          },
+          "limit": {
+            "type": "integer",
+            "default": 200,
+            "description": "Max rows/triples returned (default 200, max 1000). Ignored for UPDATE queries. Check truncated:true in response for more results; use SPARQL OFFSET to paginate."
+          }
+        }
       }
     },
     {

--- a/src/__tests__/stores/queryGraph_integration.test.ts
+++ b/src/__tests__/stores/queryGraph_integration.test.ts
@@ -188,6 +188,18 @@ describe("sparqlQuery worker command (Comunica integration)", () => {
       .toEqual([`${EX}Alice`, `${EX}Bob`].sort());
   }, 60000);
 
+  it("invalid SPARQL rejects the promise with a parse error", async () => {
+    let caughtError: unknown = null;
+    try {
+      // "SELECT WHERE { }" — missing variables, Comunica parser rejects this
+      await rdfManager.sparqlQuery("SELECT WHERE { }");
+    } catch (e) {
+      caughtError = e;
+    }
+    expect(caughtError).not.toBeNull();
+    expect(String(caughtError)).toMatch(/parse error/i);
+  }, 10000);
+
   it("no test data present before loading returns zero rows", async () => {
     const result = await rdfManager.sparqlQuery(
       `SELECT ?s WHERE { ?s a <http://example.org/sparql-test/Person> }`

--- a/src/__tests__/stores/queryGraph_integration.test.ts
+++ b/src/__tests__/stores/queryGraph_integration.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import { initRdfManagerWorker } from "../utils/initRdfManagerWorker";
+import { rdfManager } from "../../utils/rdfManager";
+
+const GRAPH = "urn:vg:data";
+
+const TURTLE_FIXTURE = `
+@prefix ex: <http://example.org/sparql-test/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+ex:Alice a ex:Person ;
+    rdfs:label "Alice" ;
+    ex:knows ex:Bob .
+
+ex:Bob a ex:Person ;
+    rdfs:label "Bob" .
+
+ex:Charlie a ex:Robot ;
+    rdfs:label "Charlie" .
+`.trim();
+
+describe("sparqlQuery worker command (Comunica integration)", () => {
+  beforeEach(async () => {
+    await initRdfManagerWorker();
+    rdfManager.clear();
+    await new Promise((r) => setTimeout(r, 100));
+  });
+
+  it("SELECT returns correct bindings", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await rdfManager.sparqlQuery(
+      `SELECT ?s ?label WHERE {
+         ?s a <http://example.org/sparql-test/Person> .
+         ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+       } ORDER BY ?label`,
+      { limit: 50 }
+    );
+
+    expect(result.type).toBe("select");
+    expect(Array.isArray(result.rows)).toBe(true);
+    expect(result.rows.length).toBe(2);
+    const labels = result.rows.map((r: Record<string, string>) => r.label);
+    expect(labels).toEqual(["Alice", "Bob"]);
+  }, 30000);
+
+  it("CONSTRUCT returns correct triples", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await rdfManager.sparqlQuery(
+      `CONSTRUCT { ?s <http://example.org/sparql-test/knows> ?o }
+       WHERE    { ?s <http://example.org/sparql-test/knows> ?o }`,
+      { limit: 50 }
+    );
+
+    expect(result.type).toBe("construct");
+    expect(Array.isArray(result.triples)).toBe(true);
+    expect(result.triples.length).toBe(1);
+    expect(result.triples[0]).toMatchObject({
+      s: "http://example.org/sparql-test/Alice",
+      p: "http://example.org/sparql-test/knows",
+      o: "http://example.org/sparql-test/Bob",
+    });
+  }, 30000);
+
+  it("LIMIT is respected", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await rdfManager.sparqlQuery(
+      `SELECT ?s WHERE { ?s a <http://example.org/sparql-test/Person> }`,
+      { limit: 1 }
+    );
+
+    expect(result.type).toBe("select");
+    expect(result.rows.length).toBeLessThanOrEqual(1);
+  }, 30000);
+
+  it("no test data present before loading returns zero rows", async () => {
+    const result = await rdfManager.sparqlQuery(
+      `SELECT ?s WHERE { ?s a <http://example.org/sparql-test/Person> }`
+    );
+
+    expect(result.type).toBe("select");
+    expect(result.rows.length).toBe(0);
+  }, 30000);
+});

--- a/src/__tests__/stores/queryGraph_integration.test.ts
+++ b/src/__tests__/stores/queryGraph_integration.test.ts
@@ -119,6 +119,75 @@ describe("sparqlQuery worker command (Comunica integration)", () => {
     expect(result.rows.length).toBe(2);
   }, 30000);
 
+  it("INSERT → SELECT → CONSTRUCT → UPDATE → DELETE lifecycle", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    const EX = "http://example.org/sparql-test/";
+    const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+    const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+    // 1. INSERT Dave
+    const ins = await rdfManager.sparqlQuery(
+      `INSERT DATA { GRAPH <${GRAPH}> {
+         <${EX}Dave> a <${EX}Person> .
+         <${EX}Dave> <${RDFS_LABEL}> "Dave" .
+       } }`
+    );
+    expect(ins.type).toBe("update");
+
+    // 2. SELECT — Dave must appear alongside Alice and Bob
+    const sel1 = await rdfManager.sparqlQuery(
+      `SELECT ?s ?label WHERE {
+         ?s a <${EX}Person> .
+         ?s <${RDFS_LABEL}> ?label .
+       } ORDER BY ?label`,
+      { limit: 10 }
+    );
+    expect(sel1.type).toBe("select");
+    expect(sel1.rows.length).toBe(3);
+    expect(sel1.rows.map((r: Record<string,string>) => r.label)).toEqual(["Alice", "Bob", "Dave"]);
+
+    // 3. CONSTRUCT — pull Dave's two triples
+    const con = await rdfManager.sparqlQuery(
+      `CONSTRUCT { <${EX}Dave> ?p ?o }
+       WHERE    { <${EX}Dave> ?p ?o }`,
+      { limit: 10 }
+    );
+    expect(con.type).toBe("construct");
+    expect(con.triples.length).toBe(2);
+    const preds = con.triples.map((t: { p: string }) => t.p).sort();
+    expect(preds).toEqual([RDF_TYPE, RDFS_LABEL].sort());
+
+    // 4. UPDATE — rename Dave → David
+    const upd = await rdfManager.sparqlQuery(
+      `DELETE { GRAPH <${GRAPH}> { <${EX}Dave> <${RDFS_LABEL}> ?old } }
+       INSERT { GRAPH <${GRAPH}> { <${EX}Dave> <${RDFS_LABEL}> "David" } }
+       WHERE  { GRAPH <${GRAPH}> { <${EX}Dave> <${RDFS_LABEL}> ?old } }`
+    );
+    expect(upd.type).toBe("update");
+
+    const sel2 = await rdfManager.sparqlQuery(
+      `SELECT ?label WHERE { <${EX}Dave> <${RDFS_LABEL}> ?label }`
+    );
+    expect(sel2.type).toBe("select");
+    expect(sel2.rows[0]?.label).toBe("David");
+
+    // 5. DELETE — remove Dave entirely
+    const del = await rdfManager.sparqlQuery(
+      `DELETE WHERE { GRAPH <${GRAPH}> { <${EX}Dave> ?p ?o } }`
+    );
+    expect(del.type).toBe("update");
+
+    const sel3 = await rdfManager.sparqlQuery(
+      `SELECT ?s WHERE { ?s a <${EX}Person> }`, { limit: 10 }
+    );
+    expect(sel3.type).toBe("select");
+    expect(sel3.rows.length).toBe(2);
+    expect(sel3.rows.map((r: Record<string,string>) => r.s).sort())
+      .toEqual([`${EX}Alice`, `${EX}Bob`].sort());
+  }, 60000);
+
   it("no test data present before loading returns zero rows", async () => {
     const result = await rdfManager.sparqlQuery(
       `SELECT ?s WHERE { ?s a <http://example.org/sparql-test/Person> }`

--- a/src/__tests__/stores/queryGraph_integration.test.ts
+++ b/src/__tests__/stores/queryGraph_integration.test.ts
@@ -80,6 +80,45 @@ describe("sparqlQuery worker command (Comunica integration)", () => {
     expect(result.rows.length).toBeLessThanOrEqual(1);
   }, 30000);
 
+  it("PREFIX declarations in query string are resolved correctly", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    const result = await rdfManager.sparqlQuery(
+      `PREFIX ex: <http://example.org/sparql-test/>
+       PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+       SELECT ?s ?label WHERE {
+         ?s a ex:Person .
+         ?s rdfs:label ?label .
+       } ORDER BY ?label`,
+      { limit: 50 }
+    );
+
+    expect(result.type).toBe("select");
+    expect(result.rows.length).toBe(2);
+    const labels = result.rows.map((r: Record<string, string>) => r.label);
+    expect(labels).toEqual(["Alice", "Bob"]);
+  }, 30000);
+
+  it("auto-injected prefixes from loaded Turtle resolve in query", async () => {
+    await rdfManager.loadRDFIntoGraph(TURTLE_FIXTURE, GRAPH, "text/turtle");
+    await new Promise((r) => setTimeout(r, 300));
+
+    // Mimic what injectPrefixes() does in the MCP queryGraph tool:
+    // pull registered namespaces and prepend PREFIX lines.
+    const namespaces = rdfManager.getNamespaces();
+    const prefixLines = namespaces
+      .filter(ns => ns.prefix && ns.uri)
+      .map(ns => `PREFIX ${ns.prefix}: <${ns.uri}>`)
+      .join("\n");
+    const sparql = `${prefixLines}\nSELECT ?s WHERE { ?s a ex:Person }`;
+
+    const result = await rdfManager.sparqlQuery(sparql, { limit: 50 });
+
+    expect(result.type).toBe("select");
+    expect(result.rows.length).toBe(2);
+  }, 30000);
+
   it("no test data present before loading returns zero rows", async () => {
     const result = await rdfManager.sparqlQuery(
       `SELECT ?s WHERE { ?s a <http://example.org/sparql-test/Person> }`

--- a/src/mcp/manifest.ts
+++ b/src/mcp/manifest.ts
@@ -48,13 +48,14 @@ export const mcpManifest: McpToolManifestEntry[] = [
   },
   {
     name: 'queryGraph',
-    description: 'Run a SPARQL query or update against asserted data (urn:vg:data). Workspace namespace prefixes are injected automatically. Supported forms: SELECT (return bindings), CONSTRUCT (return triples, read-only), INSERT DATA, DELETE DATA, DELETE WHERE, DELETE...INSERT...WHERE. For OWL-RL inference use runReasoning instead.',
+    description: 'Run a SPARQL query or update against the RDF store. Workspace namespace prefixes are injected automatically so you can use short prefix:local notation. Asserted data is in urn:vg:data; inferred triples (after runReasoning) are in urn:vg:inferred — plain BGP patterns match both. Supported forms: SELECT (returns {rows, total, truncated}), CONSTRUCT (returns {triples, total, truncated}), INSERT DATA, DELETE DATA, DELETE WHERE, DELETE…INSERT…WHERE (returns {updated:true}). Results are capped at limit (default 200, max 1000); truncated:true means more rows exist — use SPARQL OFFSET for pagination. For OWL-RL inference use runReasoning instead.',
     inputSchema: {
       type: 'object',
-      properties: {
-        sparql: { type: 'string' },
-      },
       required: ['sparql'],
+      properties: {
+        sparql: { type: 'string', description: 'SPARQL query or update. Prefix notation supported (e.g. ex:Alice, owl:Class).' },
+        limit: { type: 'integer', default: 200, description: 'Max rows/triples returned (default 200, max 1000). Ignored for UPDATE queries. Check truncated:true in response for more results; use SPARQL OFFSET to paginate.' },
+      },
     },
   },
   {

--- a/src/mcp/tools/graph.ts
+++ b/src/mcp/tools/graph.ts
@@ -4,7 +4,7 @@ import type { McpTool, McpResult } from '@/mcp/types';
 import { rdfManager } from '@/utils/rdfManager';
 import { getWorkspaceRefs, applyViewMode } from '@/mcp/workspaceContext';
 import { mcpManifest, mcpServerDescription } from '@/mcp/manifest';
-import { Parser as SparqlParser } from 'sparqljs';
+import { Parser as SparqlParser, Generator as SparqlGenerator } from 'sparqljs';
 import { resolveOntologyLoadUrl, WELL_KNOWN_PREFIXES } from '@/utils/wellKnownOntologies';
 import { useSettingsStore } from '@/stores/settingsStore';
 
@@ -149,15 +149,18 @@ const queryGraph: McpTool = {
   },
   async handler(params): Promise<McpResult> {
     try {
-      const { sparql: rawSparql, limit = 200 } = params as { sparql: string; limit?: number };
+      const { sparql: rawSparql, limit: rawLimit = 200 } = params as { sparql: string; limit?: number };
       if (!rawSparql) return { success: false, error: 'sparql is required' };
 
-      const sparql = injectPrefixes(rawSparql);
+      const MAX_LIMIT = 1000;
+      const effectiveLimit = Math.min(Math.max(1, rawLimit), MAX_LIMIT);
+
+      const sparqlWithPrefixes = injectPrefixes(rawSparql);
 
       // Validate parse before sending to worker (gives better error messages)
       let parsed: any;
       try {
-        parsed = new SparqlParser().parse(sparql);
+        parsed = new SparqlParser().parse(sparqlWithPrefixes);
       } catch (e) {
         return { success: false, error: `SPARQL parse error: ${String(e)}` };
       }
@@ -165,11 +168,19 @@ const queryGraph: McpTool = {
         return { success: false, error: 'ASK queries are not supported. Use SELECT or CONSTRUCT.' };
       }
 
-      const workerResult = await rdfManager.sparqlQuery(sparql, { limit });
+      // Inject LIMIT into the query planner if the query has none — avoids streaming
+      // the full result set through Comunica before the worker breaks the stream.
+      let sparql = sparqlWithPrefixes;
+      if (parsed.type === 'query' && parsed.limit == null) {
+        parsed.limit = effectiveLimit;
+        try { sparql = new SparqlGenerator().stringify(parsed); } catch (_) { /* keep original */ }
+      }
+
+      const workerResult = await rdfManager.sparqlQuery(sparql, { limit: effectiveLimit });
 
       if (workerResult.type === 'select') {
         const rows: Array<Record<string, string>> = workerResult.rows ?? [];
-        return { success: true, data: { rows, total: rows.length, truncated: rows.length >= limit } };
+        return { success: true, data: { rows, total: rows.length, truncated: rows.length >= effectiveLimit } };
       }
 
       if (workerResult.type === 'construct') {
@@ -179,7 +190,7 @@ const queryGraph: McpTool = {
           data: {
             triples,
             total: triples.length,
-            truncated: triples.length >= limit,
+            truncated: triples.length >= effectiveLimit,
             ...(triples.length === 0
               ? { notice: 'CONSTRUCT matched 0 triples. Check that WHERE patterns match asserted data.' }
               : {}),

--- a/src/workers/rdfManager.runtime.ts
+++ b/src/workers/rdfManager.runtime.ts
@@ -23,11 +23,12 @@ import { WELL_KNOWN } from "../utils/wellKnownOntologies.ts";
 import { ensureDefaultNamespaceMap } from "../constants/namespaces.ts";
 import { RDF_TYPE, RDFS_LABEL, SHACL } from "../constants/vocabularies.ts";
 import { OWL_SCHEMA_AXIOMS } from "../constants/owlSchemaData.ts";
+import { QueryEngine } from "@comunica/query-sparql-rdfjs";
 
 const RDF_TYPE_IRI = RDF_TYPE;
 const RDFS_LABEL_IRI = RDFS_LABEL;
 
-let _cachedQueryEngine: any = null;
+let _cachedQueryEngine: QueryEngine | null = null;
 
 /**
  * Create a graph term from a graph name string.
@@ -1848,11 +1849,12 @@ export function createRdfWorkerRuntime(postMessage: (message: unknown) => void):
           const limit = typeof payload?.limit === "number" ? payload.limit : 200;
 
           if (!_cachedQueryEngine) {
-            const { QueryEngine } = await import("@comunica/query-sparql-rdfjs");
             _cachedQueryEngine = new QueryEngine();
           }
           const store = getSharedStore();
-          const queryResult = await _cachedQueryEngine.query(sparql, { sources: [store] });
+          // unionDefaultGraph: true makes plain BGP patterns match quads from all named graphs
+          // (urn:vg:data, urn:vg:inferred, etc.) not just the empty default graph.
+          const queryResult = await _cachedQueryEngine.query(sparql, { sources: [store], unionDefaultGraph: true });
 
           if (queryResult.resultType === "bindings") {
             const bindingsStream = await queryResult.execute();


### PR DESCRIPTION
fix: Comunica CJS worker bundle failure + full queryGraph overhaul

- Root cause fixed: @comunica/query-sparql-rdfjs (CJS-only) was loaded via dynamic import() inside a Vite ES worker. Rollup split it into a separate chunk, breaking CJS circular init order → "Class extends value undefined" at runtime. Changed to a static import so Rollup resolves the entire Comunica tree into the main worker chunk at link time.

- Named-graph queries fixed: Added unionDefaultGraph: true to Comunica query context so plain BGP patterns match triples in urn:vg:data and urn:vg:inferred, not just the empty default graph.

- Pagination hardened: Hard cap at 1000 rows; limit is injected into the SPARQL AST via sparqljs.Generator (pushes into Comunica planner, not post-stream truncation).

- Manifest updated: queryGraph now documents the limit parameter, both named graphs, all three result shapes ({rows,total,truncated}, {triples,...}, {updated:true}), and SPARQL OFFSET pagination pattern.
