### PR TITLE
fix(metrics): bypass Comunica SPARQL engine in MetricsPanel to fix pr…

### DIFF
--- a/src/components/Canvas/MetricsPanel.tsx
+++ b/src/components/Canvas/MetricsPanel.tsx
@@ -1,11 +1,12 @@
 /**
  * @fileoverview Ontology Metrics Dashboard panel.
  *
- * Gathers structural counts from the data graph (via a handful of small SPARQL
- * COUNT queries plus rdfManager.getGraphCounts), then renders compact stat
- * cards, a per-namespace breakdown table, and a set of OQuaRE-flavored quality
- * heuristics. The pure ratio math lives in utils/ontologyMetrics so it stays
- * unit-testable; this component only does the gathering and presentation.
+ * Gathers structural counts from the data graph via rdfManager.getOntologyStats
+ * (a direct N3 store query in the worker — no Comunica / SPARQL dependency),
+ * then renders compact stat cards, a per-namespace breakdown table, and a set
+ * of OQuaRE-flavored quality heuristics. The pure ratio math lives in
+ * utils/ontologyMetrics so it stays unit-testable; this component only does
+ * the gathering and presentation.
  *
  * NOTE: the "quality" ratios are simple heuristics, NOT a certified OQuaRE
  * assessment — the UI labels them as such.
@@ -25,7 +26,6 @@ import {
   Database,
 } from 'lucide-react';
 import { rdfManager } from '../../utils/rdfManager';
-import type { NamespaceEntry } from '../../constants/namespaces';
 import {
   computeOntologyMetrics,
   formatRatio,
@@ -37,68 +37,11 @@ import { cn } from '../../lib/utils';
 const DATA_GRAPH = 'urn:vg:data';
 const INFERRED_GRAPH = 'urn:vg:inferred';
 
-/** SPARQL COUNT queries keyed by the raw-count field they populate. */
-const COUNT_QUERIES: Array<{ key: keyof OntologyRawCounts; sparql: string }> = [
-  {
-    key: 'totalTriples',
-    sparql: 'SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }',
-  },
-  {
-    key: 'subjectCount',
-    sparql: 'SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o }',
-  },
-  {
-    key: 'classCount',
-    sparql:
-      'SELECT (COUNT(DISTINCT ?c) AS ?n) WHERE { ' +
-      '{ ?c a <http://www.w3.org/2002/07/owl#Class> } UNION ' +
-      '{ ?c a <http://www.w3.org/2000/01/rdf-schema#Class> } }',
-  },
-  {
-    key: 'objectPropertyCount',
-    sparql:
-      'SELECT (COUNT(DISTINCT ?p) AS ?n) WHERE { ?p a <http://www.w3.org/2002/07/owl#ObjectProperty> }',
-  },
-  {
-    key: 'datatypePropertyCount',
-    sparql:
-      'SELECT (COUNT(DISTINCT ?p) AS ?n) WHERE { ?p a <http://www.w3.org/2002/07/owl#DatatypeProperty> }',
-  },
-  {
-    key: 'namedIndividualCount',
-    sparql:
-      'SELECT (COUNT(DISTINCT ?i) AS ?n) WHERE { ?i a <http://www.w3.org/2002/07/owl#NamedIndividual> }',
-  },
-  {
-    key: 'labeledClassCount',
-    sparql:
-      'SELECT (COUNT(DISTINCT ?c) AS ?n) WHERE { ' +
-      '{ { ?c a <http://www.w3.org/2002/07/owl#Class> } UNION ' +
-      '{ ?c a <http://www.w3.org/2000/01/rdf-schema#Class> } } ' +
-      '?c <http://www.w3.org/2000/01/rdf-schema#label> ?l }',
-  },
-];
-
 /** Per-prefix subject count for the namespace breakdown table. */
 interface NamespaceRow {
   prefix: string;
   uri: string;
   subjects: number;
-}
-
-interface SparqlSelectResult {
-  type?: string;
-  rows?: Array<Record<string, string>>;
-}
-
-/** Pull the single ?n binding out of a `SELECT (COUNT(...) AS ?n)` result. */
-function readCount(result: unknown): number {
-  const rows = (result as SparqlSelectResult)?.rows;
-  if (!Array.isArray(rows) || rows.length === 0) return 0;
-  const raw = rows[0]?.n;
-  // COUNT bindings may arrive as typed-literal strings; parse the leading int.
-  const n = Number.parseInt(String(raw ?? '').replace(/\D.*$/, ''), 10);
-  return Number.isFinite(n) && n >= 0 ? n : 0;
 }
 
 export function MetricsPanel() {
@@ -112,57 +55,24 @@ export function MetricsPanel() {
     setLoading(true);
     setError(null);
     try {
-      // Structural counts — small COUNT queries run in parallel.
-      const countResults = await Promise.all(
-        COUNT_QUERIES.map((q) => rdfManager.sparqlQuery(q.sparql, { graphName: DATA_GRAPH })),
-      );
-      const partial: Partial<OntologyRawCounts> = {};
-      COUNT_QUERIES.forEach((q, i) => {
-        partial[q.key] = readCount(countResults[i]);
-      });
-
-      // Asserted vs inferred triple counts from the per-graph tallies.
-      const graphCounts = await rdfManager.getGraphCounts();
-      const asserted = Number(graphCounts?.[DATA_GRAPH] ?? partial.totalTriples ?? 0) || 0;
-      const inferred = Number(graphCounts?.[INFERRED_GRAPH] ?? 0) || 0;
+      const stats = await rdfManager.getOntologyStats();
 
       const next: OntologyRawCounts = {
-        totalTriples: partial.totalTriples ?? 0,
-        classCount: partial.classCount ?? 0,
-        objectPropertyCount: partial.objectPropertyCount ?? 0,
-        datatypePropertyCount: partial.datatypePropertyCount ?? 0,
-        namedIndividualCount: partial.namedIndividualCount ?? 0,
-        subjectCount: partial.subjectCount ?? 0,
-        labeledClassCount: partial.labeledClassCount ?? 0,
-        assertedTriples: asserted,
-        inferredTriples: inferred,
+        totalTriples: stats.totalTriples,
+        classCount: stats.classCount,
+        objectPropertyCount: stats.objectPropertyCount,
+        datatypePropertyCount: stats.datatypePropertyCount,
+        namedIndividualCount: stats.namedIndividualCount,
+        subjectCount: stats.subjectCount,
+        labeledClassCount: stats.labeledClassCount,
+        assertedTriples: stats.assertedTriples,
+        inferredTriples: stats.inferredTriples,
       };
 
-      // Per-namespace subject breakdown: one COUNT query per registered prefix.
-      const namespaces: NamespaceEntry[] = rdfManager.getNamespaces();
-      const seen = new Set<string>();
-      const candidates = namespaces.filter((ns) => {
-        if (!ns?.uri) return false;
-        if (seen.has(ns.uri)) return false;
-        seen.add(ns.uri);
-        return true;
-      });
-      const nsCounts = await Promise.all(
-        candidates.map((ns) =>
-          rdfManager.sparqlQuery(
-            `SELECT (COUNT(DISTINCT ?s) AS ?n) WHERE { ?s ?p ?o FILTER(STRSTARTS(STR(?s), "${ns.uri.replace(/"/g, '\\"')}")) }`,
-            { graphName: DATA_GRAPH },
-          ),
-        ),
-      );
-      const rows: NamespaceRow[] = candidates
-        .map((ns, i) => ({
-          prefix: ns.prefix || ':',
-          uri: ns.uri,
-          subjects: readCount(nsCounts[i]),
-        }))
+      const rows: NamespaceRow[] = stats.namespaceBreakdown
         .filter((r) => r.subjects > 0)
-        .sort((a, b) => b.subjects - a.subjects);
+        .sort((a, b) => b.subjects - a.subjects)
+        .map((r) => ({ prefix: r.prefix || ':', uri: r.uri, subjects: r.subjects }));
 
       if (mounted.current) {
         setCounts(next);

--- a/src/components/Canvas/__tests__/MetricsPanel.test.tsx
+++ b/src/components/Canvas/__tests__/MetricsPanel.test.tsx
@@ -11,22 +11,17 @@ const hoisted = vi.hoisted(() => ({
     warning: vi.fn(),
     error: vi.fn(),
   },
-  sparqlQuery: vi.fn(),
-  getGraphCounts: vi.fn(),
-  getNamespaces: vi.fn(),
+  getOntologyStats: vi.fn(),
   onSubjectsChange: vi.fn(),
   offSubjectsChange: vi.fn(),
 }));
-const { sparqlQuery, getGraphCounts, getNamespaces, onSubjectsChange, offSubjectsChange } =
-  hoisted;
+const { getOntologyStats, onSubjectsChange, offSubjectsChange } = hoisted;
 
 vi.mock('sonner', () => ({ toast: hoisted.toastMocks }));
 
 vi.mock('../../../utils/rdfManager', () => ({
   rdfManager: {
-    sparqlQuery: hoisted.sparqlQuery,
-    getGraphCounts: hoisted.getGraphCounts,
-    getNamespaces: hoisted.getNamespaces,
+    getOntologyStats: hoisted.getOntologyStats,
     onSubjectsChange: hoisted.onSubjectsChange,
     offSubjectsChange: hoisted.offSubjectsChange,
   },
@@ -34,44 +29,34 @@ vi.mock('../../../utils/rdfManager', () => ({
 
 import { MetricsPanel } from '../MetricsPanel';
 
-const NAMESPACES = [
-  { prefix: 'ex', uri: 'http://example.org/' },
-  { prefix: 'owl', uri: 'http://www.w3.org/2002/07/owl#' },
-];
+function makeStats(overrides?: Partial<ReturnType<typeof defaultStats>>) {
+  return { ...defaultStats(), ...overrides };
+}
 
-/** Build a COUNT SELECT result with a single ?n binding. */
-function countRow(n: number) {
-  return { type: 'select', rows: [{ n: String(n) }] };
+function defaultStats() {
+  return {
+    totalTriples: 200,
+    classCount: 12,
+    objectPropertyCount: 24,
+    datatypePropertyCount: 9,
+    namedIndividualCount: 15,
+    subjectCount: 42,
+    labeledClassCount: 6,
+    assertedTriples: 200,
+    inferredTriples: 50,
+    namespaceBreakdown: [
+      { prefix: 'ex', uri: 'http://example.org/', subjects: 7 },
+      { prefix: 'owl', uri: 'http://www.w3.org/2002/07/owl#', subjects: 4 },
+    ],
+  };
 }
 
 describe('MetricsPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getNamespaces.mockReturnValue(NAMESPACES);
     onSubjectsChange.mockImplementation(() => {});
     offSubjectsChange.mockImplementation(() => {});
-    getGraphCounts.mockResolvedValue({ 'urn:vg:data': 200, 'urn:vg:inferred': 50 });
-
-    // The panel issues the 7 structural COUNT queries first (in COUNT_QUERIES
-    // order), then one COUNT per registered namespace. Map by query text so the
-    // order of the namespace queries doesn't matter.
-    // Distinct fixture values per metric so screen.getByText is unambiguous.
-    sparqlQuery.mockImplementation((sparql: string) => {
-      if (sparql.includes('COUNT(*)')) return Promise.resolve(countRow(200));
-      if (sparql.includes('COUNT(DISTINCT ?s)') && sparql.includes('STRSTARTS')) {
-        if (sparql.includes('http://example.org/')) return Promise.resolve(countRow(7));
-        return Promise.resolve(countRow(4));
-      }
-      if (sparql.includes('COUNT(DISTINCT ?s)')) return Promise.resolve(countRow(42));
-      if (sparql.includes('#Class')) {
-        if (sparql.includes('rdf-schema#label')) return Promise.resolve(countRow(6));
-        return Promise.resolve(countRow(12));
-      }
-      if (sparql.includes('ObjectProperty')) return Promise.resolve(countRow(24));
-      if (sparql.includes('DatatypeProperty')) return Promise.resolve(countRow(9));
-      if (sparql.includes('NamedIndividual')) return Promise.resolve(countRow(15));
-      return Promise.resolve(countRow(0));
-    });
+    getOntologyStats.mockResolvedValue(defaultStats());
   });
 
   afterEach(() => {
@@ -80,16 +65,14 @@ describe('MetricsPanel', () => {
 
   it('renders the structural counts as stat cards', async () => {
     render(<MetricsPanel />);
-    await waitFor(() => expect(getGraphCounts).toHaveBeenCalled());
+    await waitFor(() => expect(getOntologyStats).toHaveBeenCalled());
 
-    // Stat labels.
     await screen.findByText('Triples');
     expect(screen.getByText('Classes')).toBeTruthy();
     expect(screen.getByText('Object props')).toBeTruthy();
     expect(screen.getByText('Datatype props')).toBeTruthy();
     expect(screen.getByText('Individuals')).toBeTruthy();
 
-    // Values (200 triples, 12 classes, 24 object props, 9 datatype props, 15 individuals).
     expect(screen.getByText('200')).toBeTruthy();
     expect(screen.getByText('12')).toBeTruthy();
     expect(screen.getByText('24')).toBeTruthy();
@@ -101,12 +84,10 @@ describe('MetricsPanel', () => {
     render(<MetricsPanel />);
     await screen.findByText('Subjects by namespace');
 
-    // Both prefixes appear (ex=7 subjects, owl=4 subjects), ex sorted first.
     const exCell = screen.getByText('ex');
     const owlCell = screen.getByText('owl');
     expect(exCell).toBeTruthy();
     expect(owlCell).toBeTruthy();
-    // The subject count sits in the same row as the prefix cell.
     expect(exCell.closest('tr')?.textContent).toContain('7');
     expect(owlCell.closest('tr')?.textContent).toContain('4');
   });
@@ -117,17 +98,16 @@ describe('MetricsPanel', () => {
 
     expect(screen.getByText('Avg properties / class')).toBeTruthy();
     expect(screen.getByText('Classes with rdfs:label')).toBeTruthy();
-    // 5 of 10 classes labeled → 50%.
     expect(screen.getByText('50%')).toBeTruthy();
     expect(screen.getByText(/not a/i)).toBeTruthy();
   });
 
   it('re-gathers when the Refresh button is clicked', async () => {
     render(<MetricsPanel />);
-    await waitFor(() => expect(getGraphCounts).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getOntologyStats).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole('button', { name: 'Refresh metrics' }));
-    await waitFor(() => expect(getGraphCounts).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(getOntologyStats).toHaveBeenCalledTimes(2));
   });
 
   it('subscribes to subject changes on mount and unsubscribes on unmount', async () => {
@@ -138,8 +118,7 @@ describe('MetricsPanel', () => {
   });
 
   it('shows an empty state when there are no triples', async () => {
-    getGraphCounts.mockResolvedValue({ 'urn:vg:data': 0, 'urn:vg:inferred': 0 });
-    sparqlQuery.mockResolvedValue(countRow(0));
+    getOntologyStats.mockResolvedValue(makeStats({ totalTriples: 0, assertedTriples: 0, inferredTriples: 0, namespaceBreakdown: [] }));
     render(<MetricsPanel />);
     await screen.findByText('Load data to see metrics.');
   });

--- a/src/utils/rdfManager.impl.ts
+++ b/src/utils/rdfManager.impl.ts
@@ -1357,6 +1357,37 @@ export class RDFManagerImpl {
     return isPlainObject(counts) ? (counts as Record<string, number>) : {};
   }
 
+  async getOntologyStats(): Promise<{
+    totalTriples: number;
+    classCount: number;
+    objectPropertyCount: number;
+    datatypePropertyCount: number;
+    namedIndividualCount: number;
+    subjectCount: number;
+    labeledClassCount: number;
+    assertedTriples: number;
+    inferredTriples: number;
+    namespaceBreakdown: Array<{ prefix: string; uri: string; subjects: number }>;
+  }> {
+    const result = await this.worker.call("getOntologyStats");
+    const safe = isPlainObject(result) ? (result as Record<string, unknown>) : {};
+    const num = (v: unknown): number => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+    return {
+      totalTriples: num(safe.totalTriples),
+      classCount: num(safe.classCount),
+      objectPropertyCount: num(safe.objectPropertyCount),
+      datatypePropertyCount: num(safe.datatypePropertyCount),
+      namedIndividualCount: num(safe.namedIndividualCount),
+      subjectCount: num(safe.subjectCount),
+      labeledClassCount: num(safe.labeledClassCount),
+      assertedTriples: num(safe.assertedTriples),
+      inferredTriples: num(safe.inferredTriples),
+      namespaceBreakdown: Array.isArray(safe.namespaceBreakdown)
+        ? (safe.namespaceBreakdown as Array<{ prefix: string; uri: string; subjects: number }>)
+        : [],
+    };
+  }
+
   async fetchQuadsPage(options: {
     graphName: string;
     offset?: number;

--- a/src/utils/rdfManager.workerProtocol.ts
+++ b/src/utils/rdfManager.workerProtocol.ts
@@ -229,6 +229,7 @@ export type RDFWorkerCommandPayloads = {
     changedSubjects?: string[];
     changedSignature?: string[];
   };
+  getOntologyStats: undefined;
   /**
    * Enable or disable OPFS crash-recovery persistence for this session. The
    * enable preference is owned by the main thread (localStorage); this command
@@ -271,6 +272,7 @@ export const RDF_WORKER_COMMANDS = [
   "explainEntailment",
   "extractModule",
   "reasonIncremental",
+  "getOntologyStats",
 ] as const;
 
 export type RDFWorkerCommandName = (typeof RDF_WORKER_COMMANDS)[number];
@@ -828,6 +830,9 @@ const COMMAND_VALIDATORS: Record<RDFWorkerCommandName, CommandValidator> = {
       changedSignature,
       "reasonIncremental.changedSignature must be an array of strings when provided",
     );
+  },
+  getOntologyStats(payload) {
+    invariant(typeof payload === "undefined", "getOntologyStats payload must be undefined");
   },
 };
 

--- a/src/workers/rdfManager.runtime.ts
+++ b/src/workers/rdfManager.runtime.ts
@@ -2419,6 +2419,100 @@ export function createRdfWorkerRuntime(postMessage: (message: unknown) => void):
     return counts;
   }
 
+  function collectOntologyStats(store: any): Record<string, unknown> {
+    const DATA_GRAPH_IRI = "urn:vg:data";
+    const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    const OWL_CLASS = "http://www.w3.org/2002/07/owl#Class";
+    const RDFS_CLASS = "http://www.w3.org/2000/01/rdf-schema#Class";
+    const OWL_OBJECT_PROPERTY = "http://www.w3.org/2002/07/owl#ObjectProperty";
+    const OWL_DATATYPE_PROPERTY = "http://www.w3.org/2002/07/owl#DatatypeProperty";
+    const OWL_NAMED_INDIVIDUAL = "http://www.w3.org/2002/07/owl#NamedIndividual";
+    const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label";
+
+    try {
+      const toSet = (quads: any[]): Set<string> => {
+        const s = new Set<string>();
+        for (const q of quads) {
+          const v = q?.subject?.value;
+          if (typeof v === "string" && v.length > 0) s.add(v);
+        }
+        return s;
+      };
+
+      const owlClasses = toSet(store.getQuads(null, RDF_TYPE, OWL_CLASS, DATA_GRAPH_IRI));
+      const rdfsClasses = toSet(store.getQuads(null, RDF_TYPE, RDFS_CLASS, DATA_GRAPH_IRI));
+      const classSubjects = new Set([...owlClasses, ...rdfsClasses]);
+
+      const objectPropertyCount = toSet(store.getQuads(null, RDF_TYPE, OWL_OBJECT_PROPERTY, DATA_GRAPH_IRI)).size;
+      const datatypePropertyCount = toSet(store.getQuads(null, RDF_TYPE, OWL_DATATYPE_PROPERTY, DATA_GRAPH_IRI)).size;
+      const namedIndividualCount = toSet(store.getQuads(null, RDF_TYPE, OWL_NAMED_INDIVIDUAL, DATA_GRAPH_IRI)).size;
+
+      const allQuads = store.getQuads(null, null, null, DATA_GRAPH_IRI);
+      const allSubjects = new Set<string>();
+      for (const q of allQuads) {
+        const v = q?.subject?.value;
+        if (typeof v === "string" && v.length > 0) allSubjects.add(v);
+      }
+
+      const labeledSubjects = toSet(store.getQuads(null, RDFS_LABEL, null, DATA_GRAPH_IRI));
+      let labeledClassCount = 0;
+      for (const cls of classSubjects) {
+        if (labeledSubjects.has(cls)) labeledClassCount++;
+      }
+
+      const gc = collectGraphCountsFromStore(store);
+      const assertedTriples = gc[DATA_GRAPH_IRI] || 0;
+      const inferredTriples = gc["urn:vg:inferred"] || 0;
+      const totalTriples = assertedTriples;
+
+      const namespacePrefixes = Object.entries(workerNamespaces);
+      const nsBuckets = new Map<string, { prefix: string; uri: string; subjects: number }>();
+      for (const subj of allSubjects) {
+        for (const [prefix, uri] of namespacePrefixes) {
+          if (subj.startsWith(uri)) {
+            const existing = nsBuckets.get(uri);
+            if (existing) {
+              existing.subjects++;
+            } else {
+              nsBuckets.set(uri, { prefix, uri, subjects: 1 });
+            }
+            break;
+          }
+        }
+      }
+      const namespaceBreakdown = Array.from(nsBuckets.values())
+        .filter((r) => r.subjects > 0)
+        .sort((a, b) => b.subjects - a.subjects);
+
+      return {
+        totalTriples,
+        classCount: classSubjects.size,
+        objectPropertyCount,
+        datatypePropertyCount,
+        namedIndividualCount,
+        subjectCount: allSubjects.size,
+        labeledClassCount,
+        assertedTriples,
+        inferredTriples,
+        namespaceBreakdown,
+      };
+    } catch (err) {
+      debugLog("[VG_REASONING_WORKER] collectOntologyStats failed", err);
+      return {
+        totalTriples: 0,
+        classCount: 0,
+        objectPropertyCount: 0,
+        datatypePropertyCount: 0,
+        namedIndividualCount: 0,
+        subjectCount: 0,
+        labeledClassCount: 0,
+        assertedTriples: 0,
+        inferredTriples: 0,
+        namespaceBreakdown: [],
+      };
+    }
+  }
+
   // ── searchTerms (grounding / retrieval) ───────────────────────────────────
   //
   // Pure store query: find existing ontology terms by label or IRI local-name
@@ -3703,6 +3797,9 @@ export function createRdfWorkerRuntime(postMessage: (message: unknown) => void):
           break;
         case "getGraphCounts":
           result = collectGraphCountsFromStore(getSharedStore());
+          break;
+        case "getOntologyStats":
+          result = collectOntologyStats(getSharedStore());
           break;
         case "getNamespaces":
           result = { ...workerNamespaces };


### PR DESCRIPTION
…oduction crash

MetricsPanel crashed in production with `f.channel is not a function` and `ActorFunctionFactoryExpressionBnode is not a constructor` because it routed through Comunica which has bundling issues with lru-cache v11 and circular CJS deps under Rollup.

Add `getOntologyStats` worker command that counts entities directly from the N3 store using `store.getQuads()` — no SPARQL engine needed. Rewire MetricsPanel to use this single call instead of 7+N SPARQL COUNT queries.