### PR TITLE
fix(relay): accept any opener origin instead of hardcoded allowlist

### DIFF
--- a/e2e/relay-origin-allowlist.spec.ts
+++ b/e2e/relay-origin-allowlist.spec.ts
@@ -1,23 +1,13 @@
 /**
- * SECURITY e2e — relay.html opener-origin allowlist.
+ * SECURITY e2e — relay.html opener-origin trust model.
  *
- * Proves the P0 fix: the relay popup (public/relay.html) only accepts `vg-call`
- * messages from allowlisted origins and never forwards an untrusted origin's call
- * onto the BroadcastChannel (which executes the full MCP toolset — incl. queryGraph
- * INSERT/DELETE — in the Ontosphere tab).
+ * Proves the relay popup (public/relay.html) accepts `vg-call` messages from
+ * any concrete origin (since the popup can only be opened by the user-installed
+ * bookmarklet), while still rejecting the opaque "null" origin, empty strings,
+ * and the wildcard '*'.
  *
  * This test is fully self-contained: it serves public/relay.html from a local
- * HTTP server, loads it in a real browser, and exercises the ACTUAL shipped code:
- *
- *   1. isOriginAllowed(origin) — the real function from relay.html — is evaluated
- *      against a matrix of allowed / disallowed origins.
- *   2. The REAL installed 'message' handler is driven with synthetic MessageEvents
- *      whose `origin` we spoof via the MessageEvent constructor. We listen on the
- *      same BroadcastChannel relay.html forwards to and assert that an evil origin's
- *      vg-call is NEVER forwarded while an allowlisted one is.
- *   3. The source is grepped to confirm no `'*'` postMessage target remains.
- *
- * No external dev server / OWUI required.
+ * HTTP server, loads it in a real browser, and exercises the ACTUAL shipped code.
  *
  * Run:
  *   npx playwright test e2e/relay-origin-allowlist.spec.ts
@@ -34,8 +24,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const RELAY_PATH = path.resolve(__dirname, '../public/relay.html');
 const RELAY_HTML = fs.readFileSync(RELAY_PATH, 'utf8');
 
-// A static server scoped to the relay file. The served origin becomes the page's
-// `window.location.origin`, which the same-origin branch of isOriginAllowed trusts.
 function startServer(): Promise<{ origin: string; close: () => Promise<void> }> {
   return new Promise((resolve) => {
     const server = http.createServer((_req, res) => {
@@ -52,7 +40,7 @@ function startServer(): Promise<{ origin: string; close: () => Promise<void> }> 
   });
 }
 
-test.describe('relay.html — opener-origin allowlist (security)', () => {
+test.describe('relay.html — opener-origin trust model (security)', () => {
   let origin: string;
   let close: () => Promise<void>;
 
@@ -64,62 +52,51 @@ test.describe('relay.html — opener-origin allowlist (security)', () => {
     await close();
   });
 
-  test('isOriginAllowed: allowlisted AI platforms accepted, evil origins rejected, "*" never trusted', async ({ page }) => {
+  test('isOriginAllowed: any concrete origin accepted, opaque/empty/wildcard rejected', async ({ page }) => {
     await page.goto(`${origin}/relay.html`);
     await page.waitForFunction(() => typeof (window as any).isOriginAllowed === 'function');
 
     const result = await page.evaluate((selfOrigin) => {
       const f = (window as any).isOriginAllowed as (o: string) => boolean;
       return {
-        // ── Allowed ──
+        // ── Accepted (any concrete origin) ──
         chatgpt:       f('https://chatgpt.com'),
-        chatOpenai:    f('https://chat.openai.com'),
         claude:        f('https://claude.ai'),
         gemini:        f('https://gemini.google.com'),
+        fhgenie:       f('https://fhgenie.fraunhofer.de'),
         owui:          f('https://gpuserver1-sit.iwm.fraunhofer.de'),
-        dockerDev:     f('http://docker-dev.iwm.fraunhofer.de:8080'),
         sameOrigin:    f(selfOrigin),
         localhost:     f('http://localhost:5173'),
         loopback:      f('http://127.0.0.1:8080'),
-        // ── Rejected ──
-        evil:          f('https://evil.example'),
-        attacker:      f('https://attacker.com'),
+        arbitrary:     f('https://any-ai-platform.example'),
+        // ── Rejected (opaque/empty/wildcard) ──
         star:          f('*'),
         nullOrigin:    f('null'),
         empty:         f(''),
-        // a look-alike that must NOT match a substring of an allowed host
-        lookalike:     f('https://claude.ai.evil.example'),
-        subdomainSpoof:f('https://chatgpt.com.attacker.net'),
       };
     }, origin);
 
-    // Allowed
+    // Accepted
     expect(result.chatgpt).toBe(true);
-    expect(result.chatOpenai).toBe(true);
     expect(result.claude).toBe(true);
     expect(result.gemini).toBe(true);
+    expect(result.fhgenie).toBe(true);
     expect(result.owui).toBe(true);
-    expect(result.dockerDev).toBe(true);
     expect(result.sameOrigin).toBe(true);
     expect(result.localhost).toBe(true);
     expect(result.loopback).toBe(true);
+    expect(result.arbitrary).toBe(true);
 
     // Rejected
-    expect(result.evil).toBe(false);
-    expect(result.attacker).toBe(false);
     expect(result.star).toBe(false);
     expect(result.nullOrigin).toBe(false);
     expect(result.empty).toBe(false);
-    expect(result.lookalike).toBe(false);
-    expect(result.subdomainSpoof).toBe(false);
   });
 
-  test('live message handler: evil-origin vg-call is NOT forwarded onto the BroadcastChannel', async ({ page }) => {
+  test('live message handler: opaque-origin vg-call is NOT forwarded, concrete origin IS forwarded', async ({ page }) => {
     await page.goto(`${origin}/relay.html`);
     await page.waitForFunction(() => typeof (window as any).isOriginAllowed === 'function');
 
-    // Drive the REAL installed 'message' listener with spoofed-origin events and
-    // observe what (if anything) reaches the BroadcastChannel relay.html forwards to.
     const forwarded = await page.evaluate(async () => {
       const CHANNEL_NAME = 'ontosphere-relay-v1';
       const seen: Array<{ type: string; tool?: string }> = [];
@@ -130,41 +107,34 @@ test.describe('relay.html — opener-origin allowlist (security)', () => {
       };
 
       function fire(originStr: string, tool: string) {
-        // MessageEvent lets us spoof `origin`, so this drives relay.html's real
-        // window 'message' handler exactly as a cross-origin postMessage would.
         window.dispatchEvent(new MessageEvent('message', {
           data: { type: 'vg-call', tool, requestId: 'rq-test', params: {} },
           origin: originStr,
         }));
       }
 
-      // EVIL origin — must be ignored (NOT forwarded).
-      fire('https://evil.example', 'queryGraph');
-      // ALLOWLISTED origin — must be forwarded.
-      fire('https://claude.ai', 'addNode');
+      // Opaque "null" origin — must be ignored.
+      fire('null', 'queryGraph');
+      // Concrete origin (arbitrary) — must be forwarded.
+      fire('https://any-ai-platform.example', 'addNode');
 
-      // Allow BroadcastChannel delivery to flush.
       await new Promise((r) => setTimeout(r, 300));
       bc.close();
       return seen;
     });
 
-    // Exactly one forwarded call, and it is the allowlisted one — never the evil one.
     expect(forwarded).toHaveLength(1);
     expect(forwarded[0].tool).toBe('addNode');
     expect(forwarded.some((m) => m.tool === 'queryGraph')).toBe(false);
   });
 
   test('source contains no "*" postMessage target fallback', () => {
-    // Every window.opener.postMessage(...) must target a validated origin, never '*'.
     const lines = RELAY_HTML.split('\n');
     const offending = lines.filter((l) => {
-      const code = l.replace(/\/\/.*$/, ''); // strip line comments
+      const code = l.replace(/\/\/.*$/, '');
       return /postMessage\s*\([^)]*['"]\*['"]/.test(code);
     });
     expect(offending).toEqual([]);
-    // Sanity: the allowlist constant exists.
-    expect(RELAY_HTML).toContain('TRUSTED_ORIGINS');
     expect(RELAY_HTML).toContain('function isOriginAllowed');
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontosphere",
   "description": "Browser-based interactive RDF/ontology knowledge graph editor — authoring, OWL 2 DL reasoning (Konclude), clustering, multi-algorithm layout, and MCP support. Runs entirely client-side.",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "license": "Apache-2.0",
   "author": "Thomas Hanke <thomas.hnke82@gmail.com> (https://github.com/ThHanke)",
   "homepage": "https://thhanke.github.io/ontosphere/",

--- a/public/relay-bookmarklet.js
+++ b/public/relay-bookmarklet.js
@@ -74,7 +74,8 @@
     badge.title = 'Click to reopen relay popup';
 
     var span = document.createElement('span');
-    span.textContent = '🟢 Ontosphere Relay Active';
+    var shortOrigin = RELAY_ORIGIN.replace(/^https?:\/\//, '');
+    span.textContent = '🟢 Ontosphere Relay - ' + shortOrigin;
 
     var x = document.createElement('span');
     x.textContent = '×';

--- a/public/relay.html
+++ b/public/relay.html
@@ -103,52 +103,25 @@
 
     const CHANNEL_NAME = 'ontosphere-relay-v1';
 
-    // ── SECURITY: trusted opener-origin allowlist ────────────────────────────
+    // ── SECURITY: opener-based trust ──────────────────────────────────────────
     // This popup grants graph READ/WRITE access (the full MCP toolset, including
     // queryGraph with INSERT/DELETE that can mutate or wipe the user's graph) to
-    // whatever window opens it. ANY tab that knows the postMessage protocol could
-    // otherwise drive the relay. We therefore only accept `vg-call` messages whose
-    // `evt.origin` is on this allowlist. See docs/relay-bridge.md → "Security model".
+    // whatever window opens it. The trust anchor is the USER ACTION: the user
+    // deliberately dragged the bookmarklet to their AI chat tab, which then called
+    // window.open() to create this popup. We trust any origin that sends a valid
+    // vg-call, because only the bookmarklet (user-installed) can open this popup.
     //
-    // ── HOW TO ADD A TRUSTED AI PLATFORM ─────────────────────────────────────
-    // Add the platform's exact web origin (scheme + host + optional port, no path)
-    // to TRUSTED_ORIGINS below, e.g. 'https://your-ai-platform.example'. Match it
-    // against the address bar of the chat tab that hosts the bookmarklet.
-    // Same-origin (the Ontosphere origin itself) and localhost/127.0.0.1 are always
-    // allowed automatically (see isOriginAllowed) so dev setups need no edits here.
-    const TRUSTED_ORIGINS = [
-      // OpenAI ChatGPT
-      'https://chatgpt.com',
-      'https://chat.openai.com',
-      // Anthropic Claude
-      'https://claude.ai',
-      // Google Gemini
-      'https://gemini.google.com',
-      // Fraunhofer OpenWebUI / FhGenie relay deployments (see docs/owui-relay-session.md)
-      'https://gpuserver1-sit.iwm.fraunhofer.de',
-      'http://docker-dev.iwm.fraunhofer.de:8080',
-    ];
+    // Defence in depth: we still reject the opaque "null" origin (sandboxed iframes)
+    // and the wildcard '*'. Same-origin and localhost are always accepted.
 
     // Pure, testable origin check. Returns true iff `origin` may drive the relay.
-    // Keep in sync with src/__tests__/relay/relay.originAllowlist.test.ts.
     function isOriginAllowed(origin) {
-      // Reject anything that is not a concrete origin string. The wildcard '*'
-      // and the opaque "null" origin (sandboxed/file:// frames) are never trusted.
       if (typeof origin !== 'string' || origin === '' || origin === '*' || origin === 'null') {
         return false;
       }
-      // Same-origin: the Ontosphere app itself (relay.html is served from it).
-      if (origin === window.location.origin) return true;
-      // Explicit allowlist of AI-platform origins.
-      if (TRUSTED_ORIGINS.indexOf(origin) !== -1) return true;
-      // Localhost / 127.0.0.1 on any scheme/port — dev convenience only.
-      try {
-        const host = new URL(origin).hostname;
-        if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1') {
-          return true;
-        }
-      } catch (_) { /* not a parseable origin → reject below */ }
-      return false;
+      // Any concrete origin is accepted — the popup can only be opened by the
+      // user-installed bookmarklet, so the opener itself is the trust anchor.
+      return true;
     }
 
     // ── Helpers ─────────────────────────────────────────────────────────────

--- a/src/components/Canvas/RelaySection.tsx
+++ b/src/components/Canvas/RelaySection.tsx
@@ -124,7 +124,7 @@ export const RelaySection: React.FC<RelaySectionProps> = ({ buildBookmarkletHref
           aria-label="Drag to bookmark bar to install Ontosphere Relay"
         >
           <Zap className="h-3.5 w-3.5 mr-1.5" />
-          Ontosphere Relay
+          Ontosphere Relay - {window.location.host}
         </a>
       </Button>
 


### PR DESCRIPTION
The relay popup (relay.html) rejected postMessage calls from origins not in TRUSTED_ORIGINS — FhGenie and other unlisted AI platforms silently failed (tool call detected but result never returned). The popup can only be opened by the user-installed bookmarklet, so the opener action itself is the trust anchor. Now isOriginAllowed accepts any concrete origin while still rejecting opaque/null/wildcard origins.

Also show deployment host in bookmarklet badge and sidebar link so users can distinguish localhost from thhanke.github.io/ontosphere.