### PR TITLE
fix: resolve entailment explanation labels from N3 store instead of u…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontosphere",
   "description": "Browser-based interactive RDF/ontology knowledge graph editor — authoring, OWL 2 DL reasoning (Konclude), clustering, multi-algorithm layout, and MCP support. Runs entirely client-side.",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "license": "Apache-2.0",
   "author": "Thomas Hanke <thomas.hnke82@gmail.com> (https://github.com/ThHanke)",
   "homepage": "https://thhanke.github.io/ontosphere/",

--- a/src/components/Canvas/EntailmentExplanation.tsx
+++ b/src/components/Canvas/EntailmentExplanation.tsx
@@ -4,7 +4,7 @@ import { HelpCircle } from 'lucide-react';
 import { rdfManager } from '../../utils/rdfManager';
 import { PrefixContext } from '../../providers/PrefixContext';
 import { prefixShorten } from '../../providers/prefixShorten';
-import { lookupLabel } from './search/useSearchIndex';
+import { dataProvider } from './ReactodiaCanvas';
 
 const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const SUBCLASS_OF = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
@@ -32,7 +32,7 @@ function formatAxiom(
 }
 
 function labelOrLocal(iri: string): string {
-  return lookupLabel(iri) ?? iri.split(/[/#]/).pop() ?? iri;
+  return dataProvider.labelForIri(iri) ?? iri.split(/[/#]/).pop() ?? iri;
 }
 
 function formatAxiomReadable(

--- a/src/components/Canvas/search/useSearchIndex.ts
+++ b/src/components/Canvas/search/useSearchIndex.ts
@@ -10,13 +10,6 @@ const RDFS_LABEL = 'http://www.w3.org/2000/01/rdf-schema#label';
 
 let _entities: ReadonlyArray<ElementModel> = [];
 
-export function lookupLabel(iri: string): string | undefined {
-  for (const e of _entities) {
-    if (e.id === iri) return entityLabel(e);
-  }
-  return undefined;
-}
-
 function entityLabel(entity: ElementModel): string {
   const labels = entity.properties[RDFS_LABEL];
   if (labels && labels.length > 0) {

--- a/src/providers/N3DataProvider.ts
+++ b/src/providers/N3DataProvider.ts
@@ -200,6 +200,7 @@ const TBOX_BASE_TYPES = [
 
 const RDFS_SUB_CLASS_OF   = 'http://www.w3.org/2000/01/rdf-schema#subClassOf';
 const RDFS_SUB_PROP_OF    = 'http://www.w3.org/2000/01/rdf-schema#subPropertyOf';
+const RDFS_LABEL          = 'http://www.w3.org/2000/01/rdf-schema#label';
 
 export class N3DataProvider implements DataProvider {
   private inner = new RdfDataProvider({
@@ -702,6 +703,17 @@ export class N3DataProvider implements DataProvider {
 
   connectedLinkStats(p: { elementId: ElementIri; inexactCount?: boolean; signal?: AbortSignal }): Promise<DataProviderLinkCount[]> {
     return this.inner.connectedLinkStats(p);
+  }
+
+  labelForIri(iri: string): string | undefined {
+    const dataset = (this.inner as any).dataset;
+    if (!dataset) return undefined;
+    const subject = this.inner.factory.namedNode(iri);
+    const predicate = this.inner.factory.namedNode(RDFS_LABEL);
+    for (const q of dataset.iterateMatches(subject, predicate, null)) {
+      if (q.object.termType === 'Literal' && q.object.value) return q.object.value;
+    }
+    return undefined;
   }
 
   async lookup(p: DataProviderLookupParams): Promise<DataProviderLookupItem[]> {


### PR DESCRIPTION
…nified search

The unified search index only contained labels from data graph entities (urn:vg:data, urn:vg:inferred), missing ontology term labels. Switch to querying the N3DataProvider dataset directly which includes all graphs.

Bump version to 1.7.2.