### PR TITLE
fix: preserve original URL scheme when fetching ontologies

### DIFF
--- a/src/stores/ontologyStore.ts
+++ b/src/stores/ontologyStore.ts
@@ -623,12 +623,15 @@ export const useOntologyStore = create<OntologyStore>((set, get) => ({
       // normalize requested URL (http -> https, trim)
       const normRequestedUrl = normalizeOntologyUri(url);
       // Resolve to the actual fetch URL (ontologyUrl overrides namespace URL for well-known entries).
-      // Try both the normalized (https) form and the original http form because WELL_KNOWN urls use http://.
+      // Try both the normalized (https) form and the original http form because WELL_KNOWN keys use http://.
+      // For non-well-known URLs, preserve the original scheme so plain http sources work.
       const _httpForm0 = normRequestedUrl.replace(/^https:\/\//i, "http://");
       const _resolved0 = resolveOntologyLoadUrl(normRequestedUrl);
-      const fetchUrl = normalizeOntologyUri(
-        _resolved0 !== normRequestedUrl ? _resolved0 : resolveOntologyLoadUrl(_httpForm0)
-      );
+      const _resolved1 = resolveOntologyLoadUrl(_httpForm0);
+      const fetchUrl =
+        _resolved0 !== normRequestedUrl ? _resolved0
+        : _resolved1 !== _httpForm0 ? _resolved1
+        : url.trim();
       let canonicalNorm: string | undefined = undefined;
 
       // If well-known, register a lightweight entry so UI shows it immediately.

--- a/src/utils/rdfManager.impl.ts
+++ b/src/utils/rdfManager.impl.ts
@@ -160,16 +160,21 @@ const resolveJsonLdContexts = async (
     if (typeof entry !== "string") return entry;
     if (!entry.startsWith("http://") && !entry.startsWith("https://")) return entry;
     contextUrls.push(entry);
-    // Upgrade http→https to avoid Firefox CORS failures on 301 redirects
-    const fetchUrl = entry.startsWith("http://") ? entry.replace("http://", "https://") : entry;
-    try {
-      const resp = await fetchFn(fetchUrl, { Accept: "application/ld+json, application/json" }, signal);
-      if (!resp.ok) return entry;
-      const body = await resp.json();
-      return body?.["@context"] ?? body;
-    } catch {
-      return entry;
+    // Try https first to avoid Firefox CORS failures on 301 redirects,
+    // then fall back to the original scheme so plain http sources still work.
+    const httpsUrl = entry.startsWith("http://") ? entry.replace("http://", "https://") : entry;
+    const urlsToTry = httpsUrl !== entry ? [httpsUrl, entry] : [entry];
+    for (const url of urlsToTry) {
+      try {
+        const resp = await fetchFn(url, { Accept: "application/ld+json, application/json" }, signal);
+        if (!resp.ok) continue;
+        const body = await resp.json();
+        return body?.["@context"] ?? body;
+      } catch {
+        continue;
+      }
     }
+    return entry;
   };
 
   if (Array.isArray(ctx)) {


### PR DESCRIPTION
normalizeOntologyUri() rewrote http:// to https:// and that normalized form was also used as the fetch URL, making plain http sources unreachable (ERR_SSL_PROTOCOL_ERROR). Separate identity key (always https for dedup) from fetch URL (original scheme preserved).

Also add http fallback in JSON-LD context resolution so @context URLs served over plain http are reachable.

Fixes #37