### PR TITLE
fix: Docker build and runtime — four build failures plus HTTPS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,15 @@ WORKDIR /app
 # Copy manifests first so dependency installation is cached as a separate layer.
 COPY package.json package-lock.json ./
 
-# Install exact locked versions (no network calls beyond npm registry).
-RUN npm ci
+# Install exact locked versions; skip postinstall (patches/ and scripts/ not yet copied).
+RUN npm ci --ignore-scripts
 
-# Copy the rest of the source tree and build.
+# Copy the rest of the source tree, then run postinstall (patch-package + copy-konclude-assets).
 COPY . .
-RUN npm run build
+RUN npm run postinstall
+
+# Build for root path (Docker serves from /, not /ontosphere/ like GitHub Pages).
+RUN VITE_BASE_PATH=/ npm run build
 
 # ── Stage 2: serve ────────────────────────────────────────────────────────────
 # Minimal Node runtime; no build tools, no source, only dist/.
@@ -25,22 +28,27 @@ WORKDIR /app
 # express is already a runtime dependency (listed in package.json dependencies),
 # so we install only it rather than the full node_modules tree.
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 # Copy built assets and the production server script from the builder stage.
 COPY --from=builder /app/dist ./dist
-
-# Production static server — sets the required COOP/COEP headers for SharedArrayBuffer
-# (used by the Konclude WASM reasoner).
-# See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements
 COPY --from=builder /app/docker-static-server.js ./
+
+# Self-signed TLS cert so SharedArrayBuffer works on non-localhost hostnames.
+# Set HTTPS=false at runtime to disable.
+RUN apt-get update -qq && apt-get install -y --no-install-recommends openssl \
+    && mkdir -p certs \
+    && openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+         -keyout certs/key.pem -out certs/cert.pem -days 365 -nodes \
+         -subj "/CN=ontosphere-docker" \
+    && apt-get purge -y openssl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 8080
 
 ENV PORT=8080 \
     NODE_ENV=production
 
-# One-command run (after image build):
+# HTTPS by default; set HTTPS=false for plain HTTP (OWL reasoner needs HTTPS on remote hosts).
 #   docker run --rm -p 8080:8080 ontosphere:latest
-# Then open http://localhost:8080 in a Chromium-based browser.
+# Then open https://localhost:8080 in a Chromium-based browser.
 CMD ["node", "docker-static-server.js"]

--- a/README.md
+++ b/README.md
@@ -799,8 +799,19 @@ npm run typecheck:ratchet  # TypeScript error ratchet
 # Build the image
 docker build -t ontosphere:latest .
 
-# Run the static server (opens on http://localhost:8080)
+# Run the static server (HTTPS on https://localhost:8080)
 docker run --rm -p 8080:8080 ontosphere:latest
+```
+
+The container serves **HTTPS with a self-signed certificate** by default so that
+`SharedArrayBuffer` (required by the OWL WASM reasoner) works on remote hostnames,
+not just `localhost`. Your browser will show a certificate warning on first visit —
+accept it to proceed.
+
+To disable HTTPS and serve plain HTTP instead (OWL reasoner will only work on `localhost`):
+
+```sh
+docker run --rm -p 8080:8080 -e HTTPS=false ontosphere:latest
 ```
 
 The Dockerfile uses a two-stage build (Node 22 slim builder → Node 22 slim server) and pins

--- a/docker-static-server.js
+++ b/docker-static-server.js
@@ -5,11 +5,16 @@
  * so that SharedArrayBuffer is available, which the Konclude WASM reasoner
  * requires (https://developer.chrome.com/blog/enabling-shared-array-buffer).
  *
+ * Serves HTTPS by default (self-signed cert generated at image build) so
+ * SharedArrayBuffer works on remote hostnames. Set HTTPS=false to serve HTTP.
+ *
  * Usage (inside container):  node docker-static-server.js
  * Direct usage:               PORT=8080 node docker-static-server.js
  */
 
 import express from 'express';
+import https from 'node:https';
+import fs from 'node:fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -17,6 +22,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 const PORT = process.env.PORT || 8080;
 const DIST = path.join(__dirname, 'dist');
+const CERT_DIR = path.join(__dirname, 'certs');
+const useHttps = (process.env.HTTPS ?? 'true').toLowerCase() !== 'false';
 
 // Cross-origin isolation headers — required for SharedArrayBuffer (WASM pthreads).
 app.use((_req, res, next) => {
@@ -30,7 +37,6 @@ app.use(
   express.static(DIST, {
     maxAge: '1y',
     immutable: true,
-    // Do not set cache for the entry-point HTML itself.
     setHeaders(res, filePath) {
       if (filePath.endsWith('.html')) {
         res.setHeader('Cache-Control', 'no-cache');
@@ -40,11 +46,24 @@ app.use(
 );
 
 // SPA fallback — all unknown GET paths serve index.html so client-side routing works.
-app.get('*', (_req, res) => {
+app.use((_req, res) => {
   res.sendFile(path.join(DIST, 'index.html'));
 });
 
-app.listen(PORT, () => {
-  console.log(`Ontosphere static server listening on http://localhost:${PORT}`);
-  console.log('Cross-origin isolation headers (COOP/COEP) active — WASM reasoner will work.');
-});
+if (useHttps && fs.existsSync(path.join(CERT_DIR, 'key.pem'))) {
+  const key = fs.readFileSync(path.join(CERT_DIR, 'key.pem'));
+  const cert = fs.readFileSync(path.join(CERT_DIR, 'cert.pem'));
+  https.createServer({ key, cert }, app).listen(PORT, () => {
+    console.log(`Ontosphere static server listening on https://localhost:${PORT}`);
+    console.log('Self-signed certificate — browser will show a security warning on first visit.');
+    console.log('Cross-origin isolation headers (COOP/COEP) active — WASM reasoner will work.');
+  });
+} else {
+  app.listen(PORT, () => {
+    console.log(`Ontosphere static server listening on http://localhost:${PORT}`);
+    console.log('Cross-origin isolation headers (COOP/COEP) active — WASM reasoner will work.');
+    if (!useHttps) {
+      console.log('HTTPS disabled. SharedArrayBuffer (OWL reasoner) requires HTTPS on non-localhost hostnames.');
+    }
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,7 +69,7 @@ const App = () => {
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter basename={import.meta.env.PROD ? '/ontosphere' : '/'}>
+        <BrowserRouter basename={import.meta.env.VITE_BASE_PATH ?? (import.meta.env.PROD ? '/ontosphere' : '/')}>
           <Routes>
             <Route path="/" element={<Index />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/Canvas/ReactodiaCanvas.tsx
+++ b/src/components/Canvas/ReactodiaCanvas.tsx
@@ -1105,6 +1105,9 @@ export default function ReactodiaCanvas() {
         u.searchParams.get('rdfUrl') ||
         u.searchParams.get('vg_url') ||
         '';
+      if (startupUrl && window.location.protocol === 'https:' && startupUrl.startsWith('http://')) {
+        startupUrl = startupUrl.replace(/^http:\/\//, 'https://');
+      }
       startupApiKey = u.searchParams.get('apiKey') || '';
       startupApiKeyHeader = u.searchParams.get('apiKeyHeader') || '';
       shaclShapesParam = u.searchParams.get('shaclShapes') || '';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ function coiHeadersPlugin(): Plugin {
 
 
 export default defineConfig({
-  base: process.env.NODE_ENV === 'production' ? '/ontosphere/' : '/',
+  base: process.env.VITE_BASE_PATH ?? (process.env.NODE_ENV === 'production' ? '/ontosphere/' : '/'),
   // Dev server settings (keep for local development)
   server: {
     host: "::",


### PR DESCRIPTION
- Builder: npm ci --ignore-scripts, run postinstall after COPY
- Server: --ignore-scripts to skip devDependency patch-package
- Base path: VITE_BASE_PATH env var (Docker=/, GH Pages=/ontosphere/)
- Express 5: app.get('*') → app.use() for SPA fallback
- HTTPS with self-signed cert so SharedArrayBuffer works on remote hosts
- Auto-upgrade http:// rdfUrl to https:// on HTTPS pages (mixed content)

Fixes #35