### PR TITLE
fix: evaluate SPARQL-based SHACL constraints by passing validations t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,10 @@ Ontosphere validates RDF data against [SHACL](https://www.w3.org/TR/shacl/) (Sha
 
 SHACL validation runs automatically as part of the reasoning pipeline. After reasoning completes, the reasoning report shows SHACL violations alongside OWL inferences, with **SHACL** / **OWL** source badges on each finding. Only SHACL errors (severity `sh:Violation`) mark the data as invalid; warnings (`sh:Warning`) and info-level findings do not.
 
+Both property-based constraints (`sh:property`) and SPARQL-based constraints (`sh:sparql`) are supported. SPARQL constraints let you express checks that go beyond the built-in constraint components — any SELECT query returning `$this` bindings will flag matching focus nodes as violations.
+
+> **Note on `sh:severity`:** per the SHACL spec, `sh:severity` is declared on the *shape* (the `sh:NodeShape` or `sh:PropertyShape`), not inside the `sh:sparql` node. A `sh:severity` triple placed inside the SPARQL constraint block is ignored by the engine.
+
 Affected nodes display validation badges directly on the canvas — red for errors, amber for warnings. Clicking a finding in the reasoning report navigates to the affected node.
 
 ### Loading shapes

--- a/src/__tests__/workers/shacl-engine-smoke.test.ts
+++ b/src/__tests__/workers/shacl-engine-smoke.test.ts
@@ -9,14 +9,14 @@ const EX = 'http://example.org/';
 
 async function buildValidator() {
   const { Validator } = await import('shacl-engine') as any;
-  const { targetResolvers } = await import('shacl-engine/sparql.js') as any;
+  const { targetResolvers, validations } = await import('shacl-engine/sparql.js') as any;
   const dataModel = await import('@rdfjs/data-model') as any;
   const datasetMod = await import('@rdfjs/dataset') as any;
 
   const factory = dataModel.default ?? dataModel;
   const dataset = datasetMod.default?.dataset ?? datasetMod.dataset;
 
-  return { Validator, targetResolvers, factory, dataset };
+  return { Validator, targetResolvers, validations, factory, dataset };
 }
 
 function buildShapesDataset(
@@ -122,5 +122,96 @@ describe('shacl-engine SPARQL target smoke test', () => {
     expect(report.conforms).toBe(false);
     expect(report.results.length).toBe(1);
     expect(report.results[0].focusNode.value).toBe('urn:vg:bnode:abc123');
+  });
+});
+
+describe('shacl-engine sh:sparql constraint smoke test', () => {
+  function buildSparqlConstraintShapes(factory: any, dataset: () => any) {
+    const ds = dataset();
+    const shape = factory.namedNode(EX + 'SparqlConstraintShape');
+    const sparqlNode = factory.blankNode('sq1');
+
+    ds.add(factory.quad(shape, factory.namedNode(RDF_TYPE), factory.namedNode(SH + 'NodeShape')));
+    ds.add(factory.quad(shape, factory.namedNode(SH + 'targetClass'), factory.namedNode(EX + 'Thing')));
+    ds.add(factory.quad(shape, factory.namedNode(SH + 'sparql'), sparqlNode));
+    ds.add(factory.quad(sparqlNode, factory.namedNode(SH + 'message'), factory.literal('flag must not be true')));
+    ds.add(factory.quad(
+      sparqlNode,
+      factory.namedNode(SH + 'select'),
+      factory.literal('SELECT $this WHERE { $this <http://example.org/flag> true . }'),
+    ));
+
+    return ds;
+  }
+
+  it('reports violation when sh:sparql constraint matches (requires validations option)', async () => {
+    const { Validator, targetResolvers, validations, factory, dataset } = await buildValidator();
+    const shapesDs = buildSparqlConstraintShapes(factory, dataset);
+
+    const dataDs = dataset();
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'bad'),
+      factory.namedNode(RDF_TYPE),
+      factory.namedNode(EX + 'Thing'),
+    ));
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'bad'),
+      factory.namedNode(EX + 'flag'),
+      factory.literal('true', factory.namedNode('http://www.w3.org/2001/XMLSchema#boolean')),
+    ));
+
+    const validator = new Validator(shapesDs, { factory, targetResolvers, validations });
+    const report = await validator.validate({ dataset: dataDs });
+
+    expect(report.conforms).toBe(false);
+    expect(report.results.length).toBe(1);
+    expect(report.results[0].focusNode.value).toBe(EX + 'bad');
+  });
+
+  it('silently passes sh:sparql constraint WITHOUT validations option (demonstrates bug)', async () => {
+    const { Validator, targetResolvers, factory, dataset } = await buildValidator();
+    const shapesDs = buildSparqlConstraintShapes(factory, dataset);
+
+    const dataDs = dataset();
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'bad'),
+      factory.namedNode(RDF_TYPE),
+      factory.namedNode(EX + 'Thing'),
+    ));
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'bad'),
+      factory.namedNode(EX + 'flag'),
+      factory.literal('true', factory.namedNode('http://www.w3.org/2001/XMLSchema#boolean')),
+    ));
+
+    // Without validations — sh:sparql silently ignored
+    const validator = new Validator(shapesDs, { factory, targetResolvers });
+    const report = await validator.validate({ dataset: dataDs });
+
+    expect(report.conforms).toBe(true);
+    expect(report.results.length).toBe(0);
+  });
+
+  it('reports no violation when sh:sparql constraint does not match', async () => {
+    const { Validator, targetResolvers, validations, factory, dataset } = await buildValidator();
+    const shapesDs = buildSparqlConstraintShapes(factory, dataset);
+
+    const dataDs = dataset();
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'ok'),
+      factory.namedNode(RDF_TYPE),
+      factory.namedNode(EX + 'Thing'),
+    ));
+    dataDs.add(factory.quad(
+      factory.namedNode(EX + 'ok'),
+      factory.namedNode(EX + 'name'),
+      factory.literal('present'),
+    ));
+
+    const validator = new Validator(shapesDs, { factory, targetResolvers, validations });
+    const report = await validator.validate({ dataset: dataDs });
+
+    expect(report.conforms).toBe(true);
+    expect(report.results.length).toBe(0);
   });
 });

--- a/src/workers/rdfManager.runtime.ts
+++ b/src/workers/rdfManager.runtime.ts
@@ -1069,7 +1069,7 @@ export function createRdfWorkerRuntime(postMessage: (message: unknown) => void):
       import("@rdfjs/dataset") as Promise<any>,
     ]);
     const { Validator } = shaclMod;
-    const { targetResolvers } = sparqlMod;
+    const { targetResolvers, validations } = sparqlMod;
     const factory = dataModelMod.default ?? dataModelMod;
     const dataset = datasetMod.default?.dataset ?? datasetMod.dataset;
 
@@ -1096,7 +1096,7 @@ export function createRdfWorkerRuntime(postMessage: (message: unknown) => void):
       (q: any) => q.predicate.value === RDF_TYPE && q.object.value === SH_NODESHAPE,
     ).length;
 
-    const validator = new Validator(shapesDs, { factory, targetResolvers });
+    const validator = new Validator(shapesDs, { factory, targetResolvers, validations });
     let report: any;
     try {
       report = await validator.validate({ dataset: dataDs });


### PR DESCRIPTION
…o Validator

sh:sparql constraints were parsed and displayed but never executed because the validations map from shacl-engine/sparql.js was not passed to the Validator constructor. Add validations to the options, add smoke tests for sh:sparql constraint evaluation, and document sh:severity placement.